### PR TITLE
De-Zephyr kconfig module

### DIFF
--- a/sphinx_kconfig/__init__.py
+++ b/sphinx_kconfig/__init__.py
@@ -354,7 +354,7 @@ def kconfig_install(
     doctree.walk(visitor)
     if visitor.found_kconfig_search_directive:
         app.add_css_file("kconfig.css")
-        app.add_js_file("kconfig.mjs", type="module")
+        app.add_js_file("kconfig.js", type="module")
 
 
 def setup(app: Sphinx):

--- a/sphinx_kconfig/static/kconfig.js
+++ b/sphinx_kconfig/static/kconfig.js
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-const DB_FILE = 'kconfig.json';
+/* kconfig.json lives in the html root, this script under _static/scripts.
+ * need to gup up a couple levels to not 404 it. */
+const DB_FILE = '../../kconfig.json';
 const RESULTS_PER_PAGE_OPTIONS = [10, 25, 50];
 
 /* search state */
@@ -355,9 +357,18 @@ function doSearchFromURL() {
     doSearch();
 }
 
+function sleep(ms) {
+    return new Promise(r => setTimeout(r, ms));
+}
+
 function setupKconfigSearch() {
     /* populate kconfig-search container */
     const container = document.getElementById('__kconfig-search');
+    var tries = 0;
+    while ((!container) && (tries < 50)) {
+        sleep(20);
+        container = document.getElementById('__kconfig-search');
+    }
     if (!container) {
         console.error("Couldn't find Kconfig search container");
         return;

--- a/sphinx_kconfig/static/kconfig.js
+++ b/sphinx_kconfig/static/kconfig.js
@@ -5,7 +5,7 @@
 
 /* kconfig.json lives in the html root, this script under _static/scripts.
  * need to gup up a couple levels to not 404 it. */
-const DB_FILE = '../../kconfig.json';
+var DB_FILE = 'kconfig.json';
 const RESULTS_PER_PAGE_OPTIONS = [10, 25, 50];
 
 /* search state */
@@ -22,6 +22,17 @@ let navigation;
 let navigationPagesText;
 let navigationPrev;
 let navigationNext;
+
+/**
+ * Test if a file exists or not.
+ * @param {String} path File to test for.
+ */
+function fileExists(path) {
+    var http = new XMLHttpRequest();
+    http.open('HEAD', path, false);
+    http.send();
+    return http.status != 404;
+}
 
 /**
  * Show an error message.
@@ -490,6 +501,16 @@ function setupKconfigSearch() {
 
     /* load database */
     showProgress('Loading database...');
+
+    // find it first
+    var exists = fileExists(DB_FILE);
+    var limit = 4;
+    var total = 0;
+    while (!exists && total <= limit) {
+        DB_FILE = "../".concat(DB_FILE);
+        exists = fileExists(DB_FILE);
+        total += 1;
+    }
 
     fetch(DB_FILE)
         .then(response => response.json())


### PR DESCRIPTION
I think I got it working!

There's a few changes to the "frontend" side:

In `conf.py`, the following is needed:
```python
# make sure extensions list includes this
extensions.append('sphinx_kconfig')

# maybe not *required*, but probably should specify
# this is the path of the top-level `Kconfig` file, i.e., that which menuconfig and the like use
# "../Kconfig" should work if your conf.py is under a /docs/ or similar
kconfig_root_path = "../Kconfig"

# optional: only required if you want the search directive.  for just linking, not needed.
kconfig_generate_db = True
```

There is one other thing you should be aware of, and that is how the JavaScript search bar goes about finding the database.  Three things hold:

1. The database, `kconfig.json`, is always dumped to the root directory of the html output
2. The JavaScript that runs the search bar is either under `/_static` or `/_static/scripts`.
3. I can't figure out why Sphinx's HTML builder places the script under one or the other.

Therefore, when the script needs to load its database, it will try to find `kconfig.json` in up to 4 directories starting from where *the script* is and working upwards.  It will stop at the first non-404 result.

**This may cause unexpected HTML requests to the server** if the ``kconfig.json`` file is somehow missing.

Hopefully this is OK -- it's working on my machine, at least ;)